### PR TITLE
Fixing and tweaking tag-build.sh

### DIFF
--- a/bin/tag-build.sh
+++ b/bin/tag-build.sh
@@ -12,12 +12,12 @@ if [ -n "$clean_repo" ]; then
 fi
 
 # Determine the root directory for this git repository
-DIR="$( cd "$(git rev-parse --show-toplevel)" && pwd )"
+DIR=$(git rev-parse --show-toplevel)
 next_build_identifier=$(next-build-identifier.sh)
 
 # Write the next build identifier to the VERSION file
 echo "$next_build_identifier" > $DIR/VERSION
-git add VERSION
+git add $DIR/VERSION
 git commit -m "Bumping build identifier to \"$next_build_identifier\""
 git tag $next_build_identifier -a -m "Annotating build identifier \"$next_build_identifier\""
 git push --tags


### PR DESCRIPTION
1) Eliminating redundancy for setting $DIR

The following are functionally equivalent:

```console
DIR="$( cd "$(git rev-parse --show-toplevel)" && pwd )"
```

and

```console
DIR=$(git rev-parse --show-toplevel)
```

2) Ensuring that we add the VERSION file added at root.

The intention of the SHA1 d316a9e74f872d5ad50e78c6f5d3f232d8061993
commit was that the script could be run anywhere within the repository.
However, the previous `git add VERSION` command assumed that we were
still running in the repository's root.

This commit changes that behavior by explicitly adding the VERSION file
found at the repository root; As a result we can then call tag-build.sh
from anywhere within the repository.