### PR TITLE
Fixing -h option for build-pull-request-message

### DIFF
--- a/bin/build-pull-request-message
+++ b/bin/build-pull-request-message
@@ -34,10 +34,10 @@ OPTIND=1         # Reset in case getopts has been used previously in the shell.
 output_file=""
 verbose=0
 
-while getopts "h:" opt; do
+while getopts ":h" opt; do
     case "$opt" in
     h|\?)
-        echo ""
+        show_help
         exit 0
         ;;
     esac


### PR DESCRIPTION
Prior to this fix the -h option did not properly work, resuling in the
following:

```console
$ ./bin/build-pull-request-message -h
./bin/build-pull-request-message: option requires an argument -- h
```

With this fix, the script will now output the help text when passed a
`-h` option (see below).

```console
$ ./bin/build-pull-request-message -h
Leverage your commit messages to build your pull request message.
…
```