### PR TITLE
Make VERSION optional

### DIFF
--- a/bin/tag-build.sh
+++ b/bin/tag-build.sh
@@ -16,9 +16,14 @@ DIR=$(git rev-parse --show-toplevel)
 next_build_identifier=$(next-build-identifier.sh)
 
 # Write the next build identifier to the VERSION file
-echo "$next_build_identifier" > $DIR/VERSION
-git add $DIR/VERSION
-git commit -m "Bumping build identifier to \"$next_build_identifier\""
+read -p "Create a VERSION file? Note: This will require the ability to push to the current branch. [y/N]" -n 1 -r
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+  echo "$next_build_identifier" > $DIR/VERSION
+  git add $DIR/VERSION
+  git commit -m "Bumping build identifier to \"$next_build_identifier\""
+  git push origin
+fi
+
 git tag $next_build_identifier -a -m "Annotating build identifier \"$next_build_identifier\""
-git push --tags
-git push origin
+git push origin $next_build_identifier


### PR DESCRIPTION
## Make VERSION optional

5ac83e819de6b1b6a5ac396e6a85da2d800a15ff

Adding a VERSION file doesn't always make sense, and in some cases the master branch is protected from direct pushes. This change makes it optional to create the version file to better support other projects that follow the same versioning schema, but don't require a file to track it. Additionally, this changes it to be more explicit about what tag should be pushed, just in case the developer has extras on their local git.