### PR TITLE
Bugfix when remote tags don't match local

### DIFF
--- a/bin/next-build-identifier.sh
+++ b/bin/next-build-identifier.sh
@@ -9,5 +9,7 @@ current_year=$(date "+%Y")
 # incremented by one. If there is no build number for the current year, use a
 # build number of "1". This is ugly because we need to shell expand current_year,
 # but not the awk argument $2.
-git tag | awk -F '.' "/^v$current_year/ {if (max < \$2) {max = \$2}} END {print \"v$current_year.\"max+1}"
+git ls-remote --tags origin | \
+  awk -F '/' "/.*v$current_year.[0-9]+\$/ { print \$3 }" | \
+  awk -F '.' "/^v$current_year/ {if (max < \$2) {max = \$2}} END {print \"v$current_year.\"max+1}"
 exit 0


### PR DESCRIPTION
## Bugfix when remote tags don't match local

e14d82e07d107cc47503a99ce2908e5a4e098768

If the remote has newer tags than local, the current implementation will try to recreate the tag, then fails to push. This changes to list the tags on the remote instead of local in order to calculate the new identifier. I chose this instead of 'git fetch --tags', just to avoid any weirdness with pulling tags for someone if they don't want to.