### PR TITLE
Create aws-copy-params script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ Or clone the repository and include the `./bin/` in your `$PATH`.
 * [next-build-identifier.sh](./bin/next-build-identifier.sh) - determine the next build identifier. This is an idempotent script.
 * [build-pull-request-message](./bin/build-pull-request-message) - leverage your commit messages to build your pull request message.
 * [search_in_bundle](./bin/search_in_bundle) - search (via ag or grep) your current directory and associated bundle path
+* [aws-copy-params](./bin/aws-copy-params) - Copies SSM parameters from one path to another. Can currently copy between regions, but not accounts.

--- a/bin/aws-copy-params
+++ b/bin/aws-copy-params
@@ -15,8 +15,8 @@ parser.add_argument('-p','--source-path', help='The source path to copy all para
 parser.add_argument('-l','--source-region', help='The source region to copy all parameters from.', required=True)
 parser.add_argument('-P','--dest-path', help='The destination path to copy all parameters to.', required=True)
 parser.add_argument('-L','--dest-region', help='The destination region to copy all parameters to.', required=True)
-parser.add_argument('-o','--overwrite', help='Force overwrite of existing parameters.', required=False, default=True)
-parser.add_argument('-r','--recursive', help='Recursively copy parameters if there are subtrees.', required=False, default=False)
+parser.add_argument('-o','--overwrite', help='Force overwrite of existing parameters.', required=False, default=False, action='store_true')
+parser.add_argument('-r','--recursive', help='Recursively copy parameters if there are subtrees.', required=False, default=False, action='store_true')
 args = parser.parse_args()
 
 # Echo feedback about what's about to happen

--- a/bin/aws-copy-params
+++ b/bin/aws-copy-params
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+
+import boto3
+import pprint
+import re
+import argparse
+
+# Constants
+perPage = 10
+withDecryption = True
+
+parser = argparse.ArgumentParser(description='Copies SSM parameters from one path to another. Can currently copy between regions, but not accounts.',
+    epilog='This script is part of the https://github.com/ndlib/commandline-tools project.')
+parser.add_argument('-p','--source-path', help='The source path to copy all parameters from.', required=True)
+parser.add_argument('-l','--source-region', help='The source region to copy all parameters from.', required=True)
+parser.add_argument('-P','--dest-path', help='The destination path to copy all parameters to.', required=True)
+parser.add_argument('-L','--dest-region', help='The destination region to copy all parameters to.', required=True)
+parser.add_argument('-o','--overwrite', help='Force overwrite of existing parameters.', required=False, default=True)
+parser.add_argument('-r','--recursive', help='Recursively copy parameters if there are subtrees.', required=False, default=False)
+args = parser.parse_args()
+
+# Echo feedback about what's about to happen
+print "Copying params from %s in the %s region to %s in the %s region." % (args.source_path, args.source_region, args.dest_path, args.dest_region)
+srcClient = boto3.client('ssm', args.source_region)
+destClient = boto3.client('ssm', args.dest_region)
+getParams = {
+    'Path': args.source_path,
+    'Recursive': args.recursive,
+    'WithDecryption': withDecryption,
+    'MaxResults': perPage
+}
+nextToken = None
+while nextToken is not 'EOF':
+    if nextToken is not None:
+        getParams.update({ 'NextToken': nextToken })
+    srcResponse = srcClient.get_parameters_by_path(**getParams)
+    # Default to EOF in order to break the loop when the response has no NextToken
+    nextToken = srcResponse.get('NextToken', 'EOF')
+
+    for param in srcResponse.get('Parameters'):
+        newName = re.sub(
+                   r"^%s" % args.source_path,
+                   args.dest_path,
+                   param.get('Name')
+               )
+        print param.get('Name') + " -> " + newName
+        destResponse = destClient.put_parameter(
+            Name=newName,
+            Value=param.get('Value'),
+            Type=param.get('Type'),
+            Overwrite=args.overwrite
+        )


### PR DESCRIPTION
## Create aws-copy-params script

c47b779d635a96a43b2bbbd39d0fb80403a249d8

This adds a script that can be used to easily copy all key value pairs in AWS Parameter Store from one path to another. Can also be used to copy from one region to another.